### PR TITLE
Use class reference to configure authentication-provider

### DIFF
--- a/snippets/springboot-security-sso/src/main/java/com/camunda/demo/config/WebAppSecurityConfig.java
+++ b/snippets/springboot-security-sso/src/main/java/com/camunda/demo/config/WebAppSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.camunda.demo.config;
 
+import com.camunda.demo.filter.webapp.SpringSecurityAuthenticationProvider;
 import org.camunda.bpm.webapp.impl.security.auth.ContainerBasedAuthenticationFilter;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -30,7 +31,7 @@ public class WebAppSecurityConfig extends WebSecurityConfigurerAdapter {
 
         FilterRegistrationBean filterRegistration = new FilterRegistrationBean();
         filterRegistration.setFilter(new ContainerBasedAuthenticationFilter());
-        filterRegistration.setInitParameters(Collections.singletonMap("authentication-provider", "com.camunda.demo.filter.webapp.SpringSecurityAuthenticationProvider"));
+        filterRegistration.setInitParameters(Collections.singletonMap("authentication-provider", SpringSecurityAuthenticationProvider.class.getName()));
         filterRegistration.setOrder(101); // make sure the filter is registered after the Spring Security Filter Chain
         filterRegistration.addUrlPatterns("/camunda/app/*");
         return filterRegistration;


### PR DESCRIPTION
It is safer to use the SpringSecurityAuthenticationProvider class instead of the qualified class name string for the case that this code is copied and the package where SpringSecurityAuthenticationProvider resides is changed.